### PR TITLE
include messages in success response

### DIFF
--- a/src/ApiResponder/ApiResponderServiceProvider.php
+++ b/src/ApiResponder/ApiResponderServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SnappMarket\ApiResponder;
+
+
+use Illuminate\Support\ServiceProvider;
+
+class ApiResponderServiceProvider extends ServiceProvider
+{
+    /**
+     * @inheritdoc
+     */
+    public function register()
+    {
+        $this->registerSingletons();
+    }
+
+
+
+    /**
+     * Registers the singleton.
+     */
+    protected function registerSingletons()
+    {
+        $this->registerResponseSingleton();
+    }
+
+
+
+    /**
+     * Registers the singleton for the response.
+     */
+    protected function registerResponseSingleton()
+    {
+        $this->app->singleton('snappmarket.response', function () {
+            return app()->make(Response::class);
+        });
+    }
+}

--- a/src/ApiResponder/Response.php
+++ b/src/ApiResponder/Response.php
@@ -1,0 +1,25 @@
+<?php
+
+
+namespace SnappMarket\ApiResponder;
+
+use Emyoutis\WhiteHouseResponder\Response as WhiteHouseResponse;
+
+class Response extends WhiteHouseResponse
+{
+    /**
+     * Returns a success response based on the specified details.
+     *
+     * @param array $results
+     * @param array $metadata
+     * @param array $messages
+     *
+     * @return array
+     */
+    public function success(array $results, array $metadata = [], array $messages = [])
+    {
+        $completeMetadata = array_merge($metadata, compact('messages'));
+
+        return parent::success($results, $completeMetadata);
+    }
+}


### PR DESCRIPTION
This pull request will

- add an array with name `messages` to the `meatadata` of the success response
